### PR TITLE
feat(deliveries): add delivery tables and business logic

### DIFF
--- a/apps/api/src/db/migrations/00_initial.ts
+++ b/apps/api/src/db/migrations/00_initial.ts
@@ -1,37 +1,34 @@
-import { FLOAT, QueryInterface, STRING, UUID } from "sequelize";
+import { QueryInterface } from "sequelize";
 import { MigrationParams } from "umzug";
 
 export const up = async ({ context }: MigrationParams<QueryInterface>) => {
   const { sequelize } = context;
 
   await sequelize.transaction(async (transaction) => {
+    await sequelize.query('create extension if not exists "uuid-ossp"', {
+      transaction,
+    });
+
     await context.createSchema("weird_salads", { transaction });
-    await context.createTable(
-      {
-        tableName: "ingredients",
-        schema: "weird_salads",
-      },
-      {
-        id: {
-          type: UUID,
-          primaryKey: true,
-        },
-        name: {
-          type: STRING,
-        },
-        unit: {
-          type: STRING,
-        },
-        cost: {
-          type: FLOAT,
-        },
-        created_at: {
-          type: "TIMESTAMP",
-        },
-        updated_at: {
-          type: "TIMESTAMP",
-        },
-      },
+
+    await sequelize.query(
+      `
+      create table weird_salads.ingredients (
+        id text default uuid_generate_v4(),
+        name text,
+        unit text,
+        cost float,
+        available_quantity float,
+        created_at timestamp default (timezone('utc', now())),
+        updated_at timestamp default (timezone('utc', now())),
+        primary key (id)
+      )
+    `,
+      { transaction }
+    );
+
+    await sequelize.query(
+      "comment on column weird_salads.ingredients.id is E'@omit create'",
       { transaction }
     );
   });

--- a/apps/api/src/db/migrations/01_add_deliveries.ts
+++ b/apps/api/src/db/migrations/01_add_deliveries.ts
@@ -1,0 +1,77 @@
+import { QueryInterface } from "sequelize";
+import { MigrationParams } from "umzug";
+
+export const up = async ({ context }: MigrationParams<QueryInterface>) => {
+  const { sequelize } = context;
+
+  await sequelize.transaction(async (transaction) => {
+    await sequelize.query(
+      `
+      create table weird_salads.deliveries (
+        id text default uuid_generate_v4(),
+        created_at timestamp default (timezone('utc', now())),
+        updated_at timestamp default (timezone('utc', now())),
+        primary key (id)
+      )
+    `,
+      { transaction }
+    );
+
+    await sequelize.query(
+      "comment on column weird_salads.deliveries.id is E'@omit create'",
+      { transaction }
+    );
+
+    await sequelize.query(
+      `
+      create table weird_salads.delivery_ingredients (
+        delivery_id text references weird_salads.deliveries(id),
+        ingredient_id text references weird_salads.ingredients(id),
+        quantity float,
+        primary key (delivery_id, ingredient_id)
+      )
+    `,
+      { transaction }
+    );
+
+    await sequelize.query(
+      `
+      create or replace function weird_salads_ingredients_accept_delivery() returns trigger as
+        $$
+          begin
+            update weird_salads.ingredients set available_quantity = coalesce(available_quantity, 0) + new.quantity
+            where id = new.ingredient_id;
+            return new;
+          end;
+        $$ language plpgsql;
+    `,
+      { transaction }
+    );
+
+    await sequelize.query(
+      `
+      create trigger weird_salads_accept_delivery_trigger
+        after insert on weird_salads.delivery_ingredients
+        for each row
+        execute procedure weird_salads_ingredients_accept_delivery();
+    `,
+      { transaction }
+    );
+  });
+};
+
+export const down = async ({ context }: MigrationParams<QueryInterface>) => {
+  const { sequelize } = context;
+
+  await sequelize.transaction(async (transaction) => {
+    await context.dropTable(
+      { tableName: "deliveries", schema: "weird_salads" },
+      { transaction }
+    );
+
+    await context.dropTable(
+      { tableName: "delivery_ingredients", schema: "weird_salads" },
+      { transaction }
+    );
+  });
+};

--- a/apps/api/src/db/migrations/01_add_deliveries.ts
+++ b/apps/api/src/db/migrations/01_add_deliveries.ts
@@ -73,5 +73,15 @@ export const down = async ({ context }: MigrationParams<QueryInterface>) => {
       { tableName: "delivery_ingredients", schema: "weird_salads" },
       { transaction }
     );
+
+    await context.dropTrigger(
+      "weird_salads.delivery_ingredients",
+      "weird_salads_accept_delivery_trigger",
+      { transaction }
+    );
+
+    await context.dropFunction("weird_salads_ingredients_accept_delivery", [], {
+      transaction,
+    });
   });
 };


### PR DESCRIPTION
## feat
* Added `available_quantity` to `ingredients` table
* Add `deliveries` and `delivery_ingredients` tables to track deliveries and ingredients per delivery.
* Added trigger to update available quantity when a delivery is received for an ingredient.